### PR TITLE
Pass calwf3 output

### DIFF
--- a/doc/source/calwf3.rst
+++ b/doc/source/calwf3.rst
@@ -51,7 +51,6 @@ The :ref:`wf3ccd`, :ref:`wf32d`, :ref:`wf3cte` and :ref:`wf3ir` tasks on the oth
     >>> import wfc3tools
     >>> epar calwf3
 
-
 Running many files at the same time
 -----------------------------------
 
@@ -67,6 +66,16 @@ For example::
     for fits in glob('j*_raw.fits'):
         calwf3(fits)
 
+.. note::
+
+   ``calwf3()`` may raise a RuntimeError if the underlying ``calwf3.e`` program fails with a non-zero exit code. Review the text output during the calibration call for hints as to what went wrong.
+
+Controlling output from calwf3 in Python
+----------------------------------------
+
+When calling ``calwf3`` from Python, informational text output from the underlying ``calwf3.e`` program will be passed through ``print`` as the calibration runs, and show up in the user's terminal. This behavior can be customized by passing your own function as the ``log_func`` keyword argument to ``calwf3``. As output is read from the underlying program, the ``calwf3`` Python wrapper will call ``log_func`` with the contents of each line. (``print`` is an obvious choice for a log function, but this also provides a way to connect ``calwf3`` to the Python logging system by passing the ``logging.debug`` function or similar.)
+
+If ``log_func=None`` is passed, informational text output from the underlying program will be ignored, but the program's exit code will still be checked for successful completion.
 
 Command Line Options
 --------------------

--- a/lib/wfc3tools/calwf3.py
+++ b/lib/wfc3tools/calwf3.py
@@ -18,8 +18,8 @@ __taskname__ = "calwf3"
 
 
 def calwf3(input, printtime=False, save_tmp=False,
-           verbose=False, debug=False, parallel=True ):
-    
+           verbose=False, debug=False, parallel=True, log_func=print):
+
     call_list = ['calwf3.e']
 
     if printtime:
@@ -43,9 +43,18 @@ def calwf3(input, printtime=False, save_tmp=False,
 
     call_list.append(input)
 
-    subprocess.call(call_list)
+    subprocess.check_call(call_list)
+    proc = subprocess.Popen(
+        call_list,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+    )
+    for line in proc.stdout:
+        log_func(line.decode('utf8'))
 
-    
+    return_code = proc.wait()
+    if return_code != 0:
+        raise RuntimeError("calwf3.e exited with code {}".format(return_code))
 
 
 def run(configobj=None):

--- a/lib/wfc3tools/calwf3.py
+++ b/lib/wfc3tools/calwf3.py
@@ -43,7 +43,6 @@ def calwf3(input, printtime=False, save_tmp=False,
 
     call_list.append(input)
 
-    subprocess.check_call(call_list)
     proc = subprocess.Popen(
         call_list,
         stderr=subprocess.STDOUT,

--- a/lib/wfc3tools/calwf3.py
+++ b/lib/wfc3tools/calwf3.py
@@ -48,8 +48,9 @@ def calwf3(input, printtime=False, save_tmp=False,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
     )
-    for line in proc.stdout:
-        log_func(line.decode('utf8'))
+    if log_func is not None:
+        for line in proc.stdout:
+            log_func(line.decode('utf8'))
 
     return_code = proc.wait()
     if return_code != 0:


### PR DESCRIPTION
Two proposed changes:

  - Allow passing of a log function that is called with output lines of text from the `calwf3.e` subprocess object (default: `print()`, `None` to disable)
  - Check the exit code of `calwf3.e`

This came about from using `calwf3` in a Jupyter notebook and wanting some more visibility into what it was doing.