### PR TITLE
testing only in python 3 and simplifying the testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: c
 
 python:
-  - 2.7
   - 3.5
+  - 3.6
 
 os:
   - linux
@@ -48,31 +48,16 @@ matrix:
   include:
 
     # Test Documentation Builds
-    - python: 2.7
-      env: SETUP_CMD='build_sphinx' CONDA_DEPENDENCIES='ipython scipy matplotlib' PIP_DEPENDENCIES='sphinx_rtd_theme git+https://github.com/spacetelescope/stsci.tools.git'
-
     - python: 3.5
       env: SETUP_CMD='build_sphinx' CONDA_DEPENDENCIES='ipython scipy matplotlib' PIP_DEPENDENCIES='sphinx_rtd_theme git+https://github.com/spacetelescope/stsci.tools.git'
 
     # Try Astropy development and LTS versions
-    - python: 2.7
-      env: ASTROPY_VERSION=development
-    - python: 2.7
-      env: ASTROPY_VERSION=lts NUMPY_VERSION=1.9
     - python: 3.5
       env: ASTROPY_VERSION=development
 
     # Try older numpy versions
-    - python: 2.7
-      env: NUMPY_VERSION=1.11
-    - python: 2.7
-      env: NUMPY_VERSION=1.10
-    - python: 2.7
-      env: NUMPY_VERSION=1.9
     - python: 3.5
-      env: NUMPY_VERSION=1.10
-    - python: 3.5
-      env: NUMPY_VERSION=1.9
+      env: NUMPY_VERSION=1.14
 
 
 


### PR DESCRIPTION
Simplify the travis testing for wfc3tools and only test python 3 and later versions of numpy. 