### PR TITLE
Add environment bin to $PATH when calling calwf3.e

### DIFF
--- a/wfc3tools/calwf3.py
+++ b/wfc3tools/calwf3.py
@@ -1,7 +1,8 @@
 from __future__ import print_function
 
 # STDLIB
-import os.path
+import os
+import sys
 import subprocess
 from .version import __version_date__, __version__
 
@@ -60,10 +61,18 @@ def calwf3(input=None, output=None, printtime=False, save_tmp=False,
         if output:
             call_list.append(str(output))
 
+    # Prepend environment bin directory to PATH if necessary
+    env_bin = os.path.join(sys.exec_prefix, 'bin')
+    if (env_bin not in os.getenv('PATH')) & os.path.exists(env_bin):
+        _path = ':'.join([env_bin, os.getenv('PATH')])
+    else:
+        _path = os.getenv('PATH')
+
     proc = subprocess.Popen(
         call_list,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
+        env={'PATH':_path}
     )
 
     if log_func is not None:

--- a/wfc3tools/calwf3.py
+++ b/wfc3tools/calwf3.py
@@ -72,7 +72,8 @@ def calwf3(input=None, output=None, printtime=False, save_tmp=False,
         call_list,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
-        env={'PATH':_path}
+        env={'PATH':_path, 
+             'iref':os.getenv('iref')}
     )
 
     if log_func is not None:


### PR DESCRIPTION
I was having some minor trouble with conda environments in that running `wfc3tools.calwf3` with a particular Jupyter kernel associated with a conda environment was trying to execute `calwf3.e` from the base environment rather than the kernel environment.   The proposed fix tries to derive the appropriate `bin` path based on the result of `sys.exec_prefix` and prepends this to the PATH when calling the `calwf3.e` subprocess.  The fix should be pretty conservative in that it won't have any effect if either the environment `bin` path isn't found or if `calwf3.e` is not in it but is rather somewhere else within the PATH.  