### PR TITLE
[CI] add `tox.ini` and use OpenAstronomy testing workflows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,7 @@ jobs:
   test:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:
+      conda: true
       envs: |
         - linux: py311-xdist
         - linux: py312-xdist

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,8 +15,8 @@ jobs:
     with:
       conda: true
       envs: |
-        - linux: py311-xdist
-        - linux: py312-xdist
-        - macos: py312-xdist
-        - linux: py3-cov-xdist
+        - linux: py311
+        - linux: py312
+        - macos: py312
+        - linux: py3-cov
           coverage: codecov

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: tests
+
+on:
+  push:
+    branches:
+      - master
+      - '*x'
+    tags:
+      - '*'
+  pull_request:
+
+jobs:
+  test:
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    with:
+      envs: |
+        - linux: py39-xdist
+        - linux: py310-xdist
+        - linux: py311-xdist
+        - macos: py311-xdist
+        - linux: py311-cov
+          coverage: codecov

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,5 +18,3 @@ jobs:
         - linux: py311
         - linux: py312
         - macos: py312
-        - linux: py3-cov
-          coverage: codecov

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,9 +14,8 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:
       envs: |
-        - linux: py39-xdist
-        - linux: py310-xdist
         - linux: py311-xdist
-        - macos: py311-xdist
-        - linux: py311-cov
+        - linux: py312-xdist
+        - macos: py312-xdist
+        - linux: py3-cov-xdist
           coverage: codecov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,9 @@
 [build-system]
 requires = ["setuptools>=42", "setuptools_scm[toml]>=3.4", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.ruff]
+line-length = 127
+extend-ignore = [
+    "E501", # Line too long
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     scipy>=1.8.0
 
 [options.extras_require]
-test=
+tests =
     pytest
     astroquery
 docs =

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,9 @@ install_requires =
     scipy>=1.8.0
 
 [options.extras_require]
+test=
+    pytest
+    astroquery
 docs =
     sphinx
     sphinx-automodapi

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,47 @@
+[tox]
+env_list =
+    check-{style}
+    test{,-warnings}{,-cov}-xdist
+    build-{docs,dist}
+
+[testenv:check-style]
+description = check code style, e.g. with flake8
+skip_install = true
+deps =
+    ruff
+commands =
+    ruff check . {posargs}
+
+[testenv]
+description =
+    run tests
+    warnings: treating warnings as errors
+    cov: with coverage
+    xdist: using parallel processing
+package = editable
+deps =
+    pytest
+    xdist: pytest-xdist
+    cov: pytest-cov
+commands_pre =
+    pip freeze
+commands =
+    pytest \
+    warnings: -W error \
+    cov: --cov=. --cov-config=pyproject.toml --cov-report=term-missing --cov-report=xml \
+    xdist: -n auto \
+    {posargs}
+
+[testenv:build-docs]
+description = invoke sphinx-build to build the HTML docs
+extras = docs
+commands =
+    sphinx-build -b html docs docs/_build/html
+
+[testenv:build-dist]
+description = build wheel and sdist
+skip_install = true
+deps =
+    build
+commands =
+    python -m build .

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,10 @@ deps =
     pytest
     xdist: pytest-xdist
     cov: pytest-cov
+conda_deps =
+    hstcal
+conda_channels =
+    conda-forge
 commands_pre =
     pip freeze
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ description =
     cov: with coverage
     xdist: using parallel processing
 package = editable
+extras = tests
 deps =
     pytest
     xdist: pytest-xdist


### PR DESCRIPTION
this PR uses the OpenAstronomy CI testing workflow to run tests

<img width="649" alt="image" src="https://github.com/spacetelescope/wfc3tools/assets/16024299/e6eeca46-e7b0-4dc7-b4ae-ad6102419651">