### PR TITLE
drop support for Python 3.8

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,8 +3,9 @@
 version: 2
 
 build:
+  os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.11"
 
 sphinx:
   builder: html

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ classifier=
 [options]
 packages = find:
 zip_safe=False
-python_requires = >=3.8
+python_requires = >=3.9
 setup_requires =
     setuptools_scm
 install_requires =


### PR DESCRIPTION
Numpy is imminently dropping support for Python 3.8