### PR TITLE
use Mamba to build docs and install graphviz

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,7 +5,10 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: mambaforge-4.10
+
+conda:
+  environment: docs/rtd_environment.yaml
 
 sphinx:
   builder: html
@@ -14,6 +17,7 @@ sphinx:
 
 # Set the version of Python and requirements required to build your docs
 python:
+  system_packages: false
   install:
     - method: pip
       path: .

--- a/docs/rtd_environment.yaml
+++ b/docs/rtd_environment.yaml
@@ -1,0 +1,8 @@
+name: rtd311
+channels:
+ - conda-forge
+ - defaults
+dependencies:
+ - python=3.11
+ - pip
+ - graphviz


### PR DESCRIPTION
we can use `mambaforge` to build docs in an environment and install `graphviz` (in case `dot` or `graphviz` are needed by any Sphinx plugins in the future)