### PR TITLE
[CI] fix `master` -> `main`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ name: tests
 on:
   push:
     branches:
-      - master
+      - main
       - '*x'
     tags:
       - '*'


### PR DESCRIPTION
whoops, the `test.yml` in #77 was still set to `master` instead of `main`